### PR TITLE
Use Travis Continuous Integration to run flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    #- 3.6
+matrix:
+    allow_failures:
+        - python: 3.6
+install:
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The issues behind #46, #47, and #48 could all be found via automated testing using [flake8](http://flake8.pycqa.org).  The Travis CI is free for all open source projects like this one and to turn it on, visit https://travis-ci.org/profile/bugcrowd  This config file will have Travis CI run flake8 tests on all pull requests before they are reviewed.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Burp/lib/issues.py:97:9: F821 undefined name 'Thread'
        Thread.sleep(1000)
        ^
./Burp/lib/link_listener.py:6:23: F821 undefined name 'Desktop'
            desktop = Desktop.getDesktop()
                      ^
./ZAP/scripts/passive/CMDi.py:22:56: E999 IndentationError: unindent does not match any outer indentation level
        uri = msg.getRequestHeader().getURI().toString()
                                                       ^
1     E999 IndentationError: unindent does not match any outer indentation level
2     F821 undefined name 'Thread'
3
```