### PR TITLE
Minor tweaks (remove OWASP in relation to ZAP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![HUNT Logo](/images/logo.png)
 
 ### What is HUNT Suite?
-* HUNT Suite is a collection of Burp Suite Pro/Free and OWASP ZAP extensions.
-* Identifies common parameters vulnerable to certain vulnerability classes (Burp Suite Pro and OWASP ZAP). 
+* HUNT Suite is a collection of Burp Suite Pro/Free and ZAP extensions.
+* Identifies common parameters vulnerable to certain vulnerability classes (Burp Suite Pro and ZAP). 
 * Organize testing methodologies (Burp Suite Pro and Free).
 
 ### HUNT Parameter Scanner - Vulnerability Classes
@@ -105,7 +105,7 @@ HUNT Parameter Scanner leverages the passive scanning API within Burp. Here are 
 * On Sequencer responses
 * On Spider responses
 
-# HUNT Scanner for OWASP ZAP (Alpha - Contributed by Ricardo Lobo @_sbzo)
+# HUNT Scanner for ZAP (Alpha - Contributed by Ricardo Lobo @_sbzo)
 Hunt scanner is included into community scripts for ZAP Proxy.
 
 1. Find the "Manage Addons" icon, ensure you have ``` Python Scripting ``` and ``` Community Scripts ``` installed.

--- a/Remix/README.md
+++ b/Remix/README.md
@@ -6,9 +6,9 @@ A complete rewrite of the HUNT scanner.
 
 The [Burp Suite](https://portswigger.net/burp) extension works in both the Community (Free) and Professional versions.
 
-## ZAP Extension
+## ZAP Add-on
 
-The [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org) add-on works on that latest ZAP version (2.9.0).
+The [Zed Attack Proxy (ZAP)](https://www.zaproxy.org) add-on works on the latest versions of ZAP since 2.9.0.
 
 ## Features
 
@@ -26,7 +26,7 @@ The [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org) add-on works on that
 
 ## ToDo
 
-- [x] OWASP ZAP Plugin
+- [x] ZAP Add-on
 =======
 
 The [Burp Suite](https://portswigger.net/burp) extension works in both the Community (Free) and Professional versions.
@@ -41,7 +41,6 @@ The [Burp Suite](https://portswigger.net/burp) extension works in both the Commu
 
 ## ToDo
 
-- [ ] OWASP ZAP Plugin
 - [ ] Ability to add and modify rules
 - [ ] Identify reflected parameters
 
@@ -87,7 +86,7 @@ Add-on ZAP file will be located at: `./build/zapAddOn/bin`
 
 ### Load the add-on
 
-1. Open OWASP ZAP
+1. Open ZAP
 2. File
 3. Load Add-on file
 4. Select HUNT `.zap` file


### PR DESCRIPTION
ZAP is no longer an OWASP project. 
https://www.zaproxy.org/blog/2023-08-01-zap-is-joining-the-software-security-project/